### PR TITLE
Sharing some updates on the table-of-contents web part

### DIFF
--- a/table-of-contents/src/webparts/tableOfContents/components/TableOfContents.module.scss
+++ b/table-of-contents/src/webparts/tableOfContents/components/TableOfContents.module.scss
@@ -2,23 +2,42 @@
 
 .tableOfContents {
 
-  a {
-    color: "[theme: accent, default: #0078d7]";
-    text-decoration: none;
+    a {
+        color: rgb(50, 49, 48);
+        text-decoration: none;
 
-    &:hover {
-      text-decoration: underline;
+        &:hover {
+            color: "[theme: accent, default: #0078d7]" !important;
+        }
+
+        &:visited {
+            color: rgb(50, 49, 48);
+        }
     }
 
-    &:visited {
-      color: "[theme: accent, default: #0078d7]";
+    ul {
+        list-style: none;
+        padding-left: 20px;
     }
-  }
 
-  // hide on medium screens and smaller
-  .hideInMobileView {
-    @include ms-screen-lg-down {
-      display: none !important;
+    ul li::before {
+        content: "\25B6";
+        color: "[theme: accent, default: #0078d7]";
+        font-weight: bold;
+        display: inline-block;
+        padding-right: 7px;
+        margin-left: -15px;
+        width: 1em;
     }
-  }
+
+    ul li {
+        margin: 10px 0;
+    }
+
+    // hide on medium screens and smaller
+    .hideInMobileView {
+        @include ms-screen-lg-down {
+            display: none !important;
+        }
+    }
 }

--- a/table-of-contents/src/webparts/tableOfContents/components/TableOfContents.tsx
+++ b/table-of-contents/src/webparts/tableOfContents/components/TableOfContents.tsx
@@ -134,17 +134,18 @@ export default class TableOfContents extends React.Component<ITableOfContentsPro
    */
   private getQuerySelector(props: ITableOfContentsProps) {
     const queryParts = [];
+    const textBoxClass = '.cke_editable';
 
     if (props.showHeading2) {
-      queryParts.push(TableOfContents.h2Tag);
+      queryParts.push(textBoxClass + " " + TableOfContents.h2Tag);
     }
 
     if (props.showHeading3) {
-      queryParts.push(TableOfContents.h3Tag);
+      queryParts.push(textBoxClass + " " + TableOfContents.h3Tag);
     }
 
     if (props.showHeading4) {
-      queryParts.push(TableOfContents.h4Tag);
+      queryParts.push(textBoxClass + " " + TableOfContents.h4Tag);
     }
 
     return queryParts.join(',');


### PR DESCRIPTION
Hey Dmitry,

Thank you for the awesome SharePoint web parts 🙂 We have deployed the table-of-contents one on our production SharePoint instance. I've made a few slight changes that better suit our needs, but I decided to share them upstream, I hope they are useful to you.

There was this slightly annoying behaviour with the headings detection, which I believe is a bug. It kept including all headings on the page, regardless if they were part of the content or not. In https://github.com/dmitryrogozhny/sharepoint-lab/commit/8f911d1ca6912ff525cf13e7821fda465b2f00f6 I've changed the `getQuerySelector` to look only for headings inside textbox elements, as they are the ones I think should dictate the contents of the web part.

In https://github.com/dmitryrogozhny/sharepoint-lab/commit/6de859ce136fd7a98f0edf2fc02241ae5c367a64 I've updated the web part's CSS to look a bit better than just bullet points. Looks are kind of subjective, so feel free to cherry-pick this one. 

![image](https://user-images.githubusercontent.com/7537488/86403808-1b395280-bcb7-11ea-9673-35be332f7f53.png)

Once again, thank you for the awesome stuff!
Cheers! 🙂 
